### PR TITLE
Guile 2.2 support; depend on python 2.7

### DIFF
--- a/cad/lepton-eda/Makefile
+++ b/cad/lepton-eda/Makefile
@@ -19,7 +19,7 @@ LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
 		libstroke.so:devel/libstroke
 
 USES=		autoreconf desktop-file-utils gettext-tools gnome groff:build \
-		libtool localbase makeinfo pathfix perl5 pkgconfig python:run \
+		libtool localbase makeinfo pathfix perl5 pkgconfig python:2.7,run \
 		shared-mime-info shebangfix
 USE_GITHUB=	yes
 USE_GNOME=	cairo gtk20

--- a/cad/lepton-eda/Makefile
+++ b/cad/lepton-eda/Makefile
@@ -3,6 +3,7 @@
 PORTNAME=	lepton-eda
 PORTVERSION=	1.9.7
 DISTVERSIONSUFFIX=	-20181211
+PORTREVISION=	2
 CATEGORIES=	cad
 
 MAINTAINER=	graahnul.grom@gmail.com
@@ -13,7 +14,7 @@ LICENSE=	GPLv2+
 LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
 		libfreetype.so:print/freetype2 \
 		libgc-threaded.so:devel/boehm-gc-threaded \
-		libguile-2.0.so:lang/guile2 \
+		libguile-2.2.so:lang/guile2 \
 		libpng.so:graphics/png \
 		libstroke.so:devel/libstroke
 

--- a/cad/lepton-eda/Makefile
+++ b/cad/lepton-eda/Makefile
@@ -1,4 +1,4 @@
-# $FreeBSD: head/cad/lepton-eda/Makefile 499146 2019-04-17 05:58:06Z pi $
+# $FreeBSD$
 
 PORTNAME=	lepton-eda
 PORTVERSION=	1.9.7
@@ -57,13 +57,11 @@ NLS_USES=		gettext-runtime
 #
 # Cannot find 'install -m 0644'; You probably want to pass -x ${INSTALL_DATA}
 #
-#
-# NOTE: in the error message above (I wanted to show it
-# verbatim), INSTALL_DATA actually is enclosed in
-# parenthesis, not in curly brackets.
-# I had to change it to appease portlint(1), which does
-# not ignore comments in makefiles.
-#
+#   NOTE: in the error message above (I wanted to show it
+#   verbatim), INSTALL_DATA actually is enclosed in
+#   parenthesis, not in curly brackets.
+#   I had to change it to appease portlint(1), which does
+#   not ignore comments in makefiles.
 #
 # for 3 dirs (attrib/data, liblepton/data, schematic/data)
 # the following lines should be in the generated Makefile:

--- a/cad/lepton-eda/files/patch-m4_geda-guile.m4
+++ b/cad/lepton-eda/files/patch-m4_geda-guile.m4
@@ -1,0 +1,26 @@
+--- m4/geda-guile.m4.orig	2018-12-11 19:24:41 UTC
++++ m4/geda-guile.m4
+@@ -34,9 +34,20 @@ AC_DEFUN([AX_CHECK_GUILE],
+   GUILE_MIN_MINOR=`echo ${GUILE_MIN_VER} | sed -e 's;[[^\.]]*\.;;' -e 's;\..*;;g'`
+   GUILE_MIN_TEENY=`echo ${GUILE_MIN_VER} | sed -e 's;.*\.;;'`
+ 
+-  PKG_CHECK_MODULES(GUILE, [guile-2.0 >= $GUILE_MIN_VER],
+-                           [GUILE_PKG_NAME=guile-2.0],
+-                           [AC_MSG_ERROR([you need at least version ${GUILE_MIN_VER} of guile])])
++  _found_pkg_config_guile=yes
++  PKG_CHECK_MODULES(GUILE, [guile-2.2 >= $GUILE_MIN_VER],
++                           [GUILE_PKG_NAME=guile-2.2], [_found_pkg_config_guile=no])
++
++  if test "${_found_pkg_config_guile}" = "no" ; then
++   PKG_CHECK_MODULES(GUILE, [guile-2.0 >= $GUILE_MIN_VER],
++                            [_found_pkg_config_guile=yes
++                             GUILE_PKG_NAME=guile-2.0],
++                            [_found_pkg_config_guile=no])
++  fi
++
++  if test "${_found_pkg_config_guile}" = "no" ; then
++    AC_MSG_ERROR([you need at least version ${GUILE_MIN_VER} of guile])
++  fi
+ 
+   AC_SUBST([GUILE_PKG_NAME])
+ 

--- a/cad/lepton-eda/files/patch-schematic_scheme_gschem_action.scm
+++ b/cad/lepton-eda/files/patch-schematic_scheme_gschem_action.scm
@@ -1,0 +1,102 @@
+--- schematic/scheme/gschem/action.scm.orig	2018-12-11 19:24:41 UTC
++++ schematic/scheme/gschem/action.scm
+@@ -1,6 +1,7 @@
+ ;; Lepton EDA Schematic Capture
+ ;; Scheme API
+ ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
++;; Copyright (C) 2017-2019 Lepton EDA Contributors
+ ;;
+ ;; This program is free software; you can redistribute it and/or modify
+ ;; it under the terms of the GNU General Public License as published by
+@@ -21,11 +22,10 @@
+   #:use-module (gschem core gettext)
+   #:use-module (gschem window)
+   #:use-module (gschem hook)
++  #:use-module (geda log)
+   #:use-module (ice-9 optargs)
+   #:export-syntax (define-action))
+ 
+-(or (defined? 'define-syntax)
+-    (use-modules (ice-9 syncase)))
+ 
+ (define last-action (make-fluid))
+ (define current-action-position (make-fluid))
+@@ -33,18 +33,25 @@
+ ;; Define an eval-in-currentmodule procedure
+ (define (eval-cm expr) (eval expr (current-module)))
+ 
+-;; Evaluates a gschem action.  A gschem action is expected to be a
++;; Evaluates a lepton-schematic action.  An action is expected to be a
+ ;; symbol naming a thunk variable in the current module.
+ ;;
+ ;; The special-case symbol repeat-last-command causes the last action
+ ;; executed to be repeated.
+ (define-public (eval-action! action)
+   (define (invalid-action-error)
+-    (error (_ "~S is not a valid gschem action.") action))
++    (log! 'warning (_ "[~A] is not a valid lepton-schematic action.") action))
++  (define (no-last-action-error)
++    (log! 'message (_ "There is no last action to repeat.")))
+ 
+   (define (eval-action!/recursive a)
+ 
+     (cond
++     ;; The action is #f when the user hits "." (repeat last action)
++     ;; and there is no last action to repeat.
++     ((eq? a #f)
++      (no-last-action-error))
++
+      ;; Handle repeat-last-command
+      ((equal? 'repeat-last-command a)
+       ;; N.b. must call eval-action! rather than
+@@ -107,29 +114,30 @@
+   ;; The action is a magical procedure that does nothing but call
+   ;; eval-action! *on itself*.  This allows you to invoke an action
+   ;; just by calling it like a normal function.
+-  (letrec ((action (lambda () (eval-action! action))))
++  (let ((unique-tag (list #f)))
++    (letrec ((action (case-lambda
++                       (() (eval-action! action))
++                       ((x) unique-tag))))
+ 
+-    ;; The action data is stored in procedure properties -- most
+-    ;; importantly, the actual thunk that the action wraps
+-    (let ((sp! (lambda (k v) (set-procedure-property! action k v))))
+-      (sp! 'gschem-cookie %cookie)
+-      (sp! 'gschem-thunk thunk)
+-      (sp! 'gschem-properties '()))
++      ;; The action data is stored in procedure properties -- most
++      ;; importantly, the actual thunk that the action wraps
++      (let ((sp! (lambda (k v) (set-procedure-property! action k v))))
++        (sp! 'gschem-cookie %cookie)
++        (sp! 'gschem-thunk thunk)
++        (sp! 'gschem-properties '()))
+ 
+-    ;; Deal with any properties.  props should contain arguments in
+-    ;; pairs, where the first element of each pair is a keyword naming
+-    ;; a procedure property (e.g. #:icon) and the second element in
+-    ;; the corresponding value (e.g. "insert-text").
+-    (let loop ((lst props))
+-      (and (< 1 (length lst))
+-           (set-action-property! action
+-                                 (keyword->symbol (list-ref lst 0))
+-                                 (list-ref lst 1))
+-           (loop (list-tail lst 2))))
+-          
+-          
++      ;; Deal with any properties.  props should contain arguments in
++      ;; pairs, where the first element of each pair is a keyword naming
++      ;; a procedure property (e.g. #:icon) and the second element in
++      ;; the corresponding value (e.g. "insert-text").
++      (let loop ((lst props))
++        (and (< 1 (length lst))
++             (set-action-property! action
++                                   (keyword->symbol (list-ref lst 0))
++                                   (list-ref lst 1))
++             (loop (list-tail lst 2))))
+ 
+-    action))
++      action)))
+ 
+ (define (action-thunk action)
+   (procedure-property action 'gschem-thunk))


### PR DESCRIPTION
`lang/guile2` port was upgraded to version 2.2

- make `lepton-schematic` work with guile 2.2
- USES: python:2.7,run (lepton-archive doesn't
  work with python 3.x, https://github.com/lepton-eda/lepton-eda/issues/440)