### PR TITLE
199+: tabbed GUI improvements upstream patches

### DIFF
--- a/cad/lepton-eda/files/patch-liblepton_include_liblepton_geda__list.h
+++ b/cad/lepton-eda/files/patch-liblepton_include_liblepton_geda__list.h
@@ -1,0 +1,23 @@
+--- liblepton/include/liblepton/geda_list.h.orig	2019-10-03 20:45:55 UTC
++++ liblepton/include/liblepton/geda_list.h
+@@ -1,7 +1,8 @@
+-/* gEDA - GPL Electronic Design Automation
+- * libgeda - gEDA's library
++/* Lepton EDA library
+  * Copyright (C) 1998-2010 Ales Hvezda
+  * Copyright (C) 2007-2010 Peter Clifton
++ * Copyright (C) 2011-2015 gEDA Contributors
++ * Copyright (C) 2017-2019 Lepton EDA Contributors
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Library General Public
+@@ -56,6 +57,9 @@ void geda_list_add_glist( GedaList *list
+ void geda_list_remove( GedaList *list, gpointer item );
+ /*void geda_list_remove_glist( GedaList *list, GList *items ); */ /* Undemanded as yet */
+ void geda_list_remove_all( GedaList *list );
++void geda_list_move_item( GedaList* list, gpointer item, gint newpos );
++
++
+ 
+ /*const GList *geda_list_get_glist( GedaList *list ); */
+ #define geda_list_get_glist(list) (list->glist)

--- a/cad/lepton-eda/files/patch-liblepton_src_geda__list.c
+++ b/cad/lepton-eda/files/patch-liblepton_src_geda__list.c
@@ -1,0 +1,36 @@
+--- liblepton/src/geda_list.c.orig	2019-10-03 20:45:55 UTC
++++ liblepton/src/geda_list.c
+@@ -1,7 +1,8 @@
+-/* gEDA - GPL Electronic Design Automation
+- * libgeda - gEDA's library
++/* Lepton EDA library
+  * Copyright (C) 1998-2000 Ales Hvezda
+  * Copyright (C) 2007-2010 Peter Clifton
++ * Copyright (C) 2011-2013 gEDA Contributors
++ * Copyright (C) 2017-2019 Lepton EDA Contributors
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+@@ -179,3 +180,22 @@ void geda_list_remove_all( GedaList *lis
+   g_signal_emit( list, geda_list_signals[ CHANGED ], 0 );
+ }
+ 
++
++/*! \brief Moves the list data \a item to a new position \a newpos.
++ */
++void geda_list_move_item( GedaList* list, gpointer item, gint newpos )
++{
++  GList* gl = list->glist;
++  GList* node = g_list_find (gl, item);
++
++  if (node != NULL)
++  {
++    gl = g_list_remove_link (gl, node);
++    gl = g_list_insert (gl, item, newpos);
++    g_list_free (node);
++    list->glist = gl;
++
++    g_signal_emit( list, geda_list_signals[ CHANGED ], 0 );
++  }
++}
++

--- a/cad/lepton-eda/files/patch-schematic_src_x__tabs.c
+++ b/cad/lepton-eda/files/patch-schematic_src_x__tabs.c
@@ -1,0 +1,275 @@
+--- schematic/src/x_tabs.c.orig	2019-10-03 20:45:55 UTC
++++ schematic/src/x_tabs.c
+@@ -53,7 +53,7 @@
+  * key:         use-tabs
+  * group:       schematic.gui
+  * type:        boolean
+- * default val: false
++ * default val: true
+  *
+  * 2) Whether to show "close" button on tabs:
+  * key:         show-close-button
+@@ -75,7 +75,7 @@
+ 
+ 
+ static gboolean
+-g_x_tabs_enabled = FALSE;
++g_x_tabs_enabled = TRUE;
+ 
+ static gboolean
+ g_x_tabs_show_close_button = TRUE;
+@@ -284,6 +284,28 @@ x_tabs_page_on_sel (GtkNotebook* nbook,
+                     guint        ndx,
+                     gpointer     data);
+ 
++static void
++x_tabs_page_on_reordered (GtkNotebook* nbook,
++                          GtkWidget*   wtab,
++                          guint        newindex,
++                          gpointer     data);
++
++
++static gboolean
++x_tabs_hdr_on_mouse_click (GtkWidget* hdr, GdkEvent* e, gpointer data);
++static GtkMenu*
++x_tabs_menu_create (TabInfo* nfo);
++static void
++x_tabs_menu_create_item (GschemToplevel* toplevel,
++                         GtkWidget*      menu,
++                         const gchar*    action_name,
++                         const gchar*    action_label,
++                         const gchar*    icon_name);
++static void
++x_tabs_menu_create_item_separ (GtkWidget* menu);
++static void
++x_tabs_menu_item_on_activate (GtkAction* action, gpointer data);
++
+ 
+ 
+ /* page view: */
+@@ -409,7 +431,24 @@ x_tabs_dbg_pages_dump (GschemToplevel* w
+   printf( " ^^^^^^^^^^^^^^ pages ^^^^^^^^^^^^^^^^^^\n\n" );
+ }
+ 
+-#endif
++static void
++x_tabs_dbg_pages_dump_simple (GschemToplevel* w_current)
++{
++  printf( " >> pages:\n" );
++  g_return_if_fail( w_current != NULL );
++
++  for ( GList* node = w_current->toplevel->pages->glist;
++        node != NULL;
++        node = g_list_next( node ) )
++  {
++    PAGE* p = node->data;
++    printf( "    p: [%s]\n", g_path_get_basename( s_page_get_filename(p) ) );
++  }
++
++  printf( "\n" );
++}
++
++#endif /* DEBUG */
+ 
+ 
+ 
+@@ -661,6 +700,11 @@ x_tabs_nbook_create (GschemToplevel* w_c
+   g_signal_connect (nbook, "switch-page",
+                     G_CALLBACK (&x_tabs_page_on_sel), w_current);
+ 
++  g_signal_connect (nbook,
++                    "page-reordered",
++                    G_CALLBACK (&x_tabs_page_on_reordered),
++                    w_current);
++
+ } /* x_tabs_nbook_create() */
+ 
+ 
+@@ -913,7 +957,18 @@ x_tabs_hdr_set (GtkNotebook* nbook, TabI
+   g_return_if_fail (nfo != NULL);
+ 
+   GtkWidget* hdr = x_tabs_hdr_create (nfo);
+-  gtk_notebook_set_tab_label (nbook, nfo->wtab_, hdr);
++
++  GtkWidget* ebox = gtk_event_box_new();
++  gtk_event_box_set_visible_window (GTK_EVENT_BOX (ebox), FALSE);
++  gtk_container_add (GTK_CONTAINER (ebox), hdr);
++  gtk_widget_show_all (ebox);
++
++  g_signal_connect (ebox,
++                    "button-press-event",
++                    G_CALLBACK (&x_tabs_hdr_on_mouse_click),
++                    nfo);
++
++  gtk_notebook_set_tab_label (nbook, nfo->wtab_, ebox);
+ }
+ 
+ 
+@@ -1160,6 +1215,8 @@ x_tabs_page_new (GschemToplevel* w_curre
+   x_tabs_tl_pview_cur_set (w_current, pview);
+   gint ndx = x_tabs_nbook_page_add (w_current, page, pview, wtab);
+ 
++  gtk_notebook_set_tab_reorderable (w_current->xtabs_nbook, wtab, TRUE);
++
+   return x_tabs_info_add (w_current, ndx, page, pview, wtab);
+ 
+ } /* x_tabs_page_new() */
+@@ -1485,3 +1542,158 @@ x_tabs_page_on_sel (GtkNotebook* nbook,
+ 
+ } /* x_tabs_page_on_sel() */
+ 
++
++
++/*! \brief GtkNotebook "page-reordered" signal handler.
++ */
++static void
++x_tabs_page_on_reordered (GtkNotebook* nbook,
++                          GtkWidget*   wtab,
++                          guint        newindex,
++                          gpointer     data)
++{
++  GschemToplevel* w_current = (GschemToplevel*) data;
++  g_return_if_fail (w_current != NULL);
++  g_return_if_fail (w_current->toplevel != NULL);
++  g_return_if_fail (w_current->toplevel->pages != NULL);
++
++  TabInfo* nfo = x_tabs_info_find_by_wtab (w_current->xtabs_info_list, wtab);
++  g_return_if_fail (nfo != NULL);
++
++  GedaPageList* pages = w_current->toplevel->pages;
++  geda_list_move_item (pages, nfo->page_, newindex);
++
++  gtk_widget_grab_focus (GTK_WIDGET (nfo->pview_));
++  page_select_widget_update (w_current);
++
++#ifdef DEBUG
++  x_tabs_dbg_pages_dump_simple( w_current );
++#endif
++
++} /* x_tabs_page_on_reordered() */
++
++
++
++/*! \brief Create popup menu for tab's header.
++ */
++static GtkMenu*
++x_tabs_menu_create (TabInfo* nfo)
++{
++  g_return_val_if_fail (nfo != NULL, NULL);
++
++  GschemToplevel* tl = nfo->tl_;
++  g_return_val_if_fail (tl != NULL, NULL);
++
++  GtkWidget* menu = gtk_menu_new();
++  x_tabs_menu_create_item (tl, menu, "file-new", _("_New"), GTK_STOCK_NEW);
++  x_tabs_menu_create_item (tl, menu, "file-open", _("_Open"), GTK_STOCK_OPEN);
++  x_tabs_menu_create_item_separ (menu);
++  x_tabs_menu_create_item (tl, menu, "file-save", _("_Save"), GTK_STOCK_SAVE);
++  x_tabs_menu_create_item (tl, menu, "file-save-as", _("Save _As..."), GTK_STOCK_SAVE_AS);
++  x_tabs_menu_create_item_separ (menu);
++  x_tabs_menu_create_item (tl, menu, "page-manager", _("Page _Manager..."), NULL);
++  x_tabs_menu_create_item_separ (menu);
++  x_tabs_menu_create_item (tl, menu, "page-close", _("_Close"), GTK_STOCK_CLOSE);
++
++  gtk_widget_show_all (menu);
++  return GTK_MENU (menu);
++
++} /* x_tabs_menu_create() */
++
++
++
++/*! \brief Tab's header widget "button-press-event" signal handler.
++ *  \todo  Consider switching to clicked tab
++ */
++static gboolean
++x_tabs_hdr_on_mouse_click (GtkWidget* hdr, GdkEvent* e, gpointer data)
++{
++  g_return_val_if_fail (data != NULL, FALSE);
++  GdkEventButton* ebtn = (GdkEventButton*) e;
++
++  TabInfo* nfo    = (TabInfo*) data;
++  TabInfo* nfocur = x_tabs_info_cur (nfo->tl_);
++
++  /* show menu for current tab only:
++  */
++  if (nfo != nfocur)
++    return FALSE;
++
++#ifdef DEBUG
++  printf( "p: [%s]\n",   g_path_get_basename( s_page_get_filename(nfo->page_) ) );
++  printf( "C: [%s]\n\n", g_path_get_basename( s_page_get_filename(nfocur->page_) ) );
++#endif
++
++  if (ebtn->type == GDK_BUTTON_PRESS && ebtn->button == 3)
++  {
++    GtkMenu* menu = x_tabs_menu_create (nfo);
++
++    int btn = 0;
++    int etime = 0;
++    if (ebtn != NULL)
++    {
++      btn = ebtn->button;
++      etime = gtk_get_current_event_time();
++    }
++
++    gtk_menu_attach_to_widget (menu, hdr, NULL);
++    gtk_menu_popup (menu, NULL, NULL, NULL, NULL, btn, etime);
++
++    return TRUE;
++  }
++
++  return FALSE;
++
++} /* x_tabs_page_on_mouse_click() */
++
++
++
++/*! \brief "activate" signal handler for context menu item action.
++ */
++static void
++x_tabs_menu_item_on_activate (GtkAction* action, gpointer data)
++{
++  GschemToplevel* toplevel    = (GschemToplevel*) data;
++  const gchar*    action_name = gtk_action_get_name (action);
++
++  g_action_eval_by_name (toplevel, action_name);
++}
++
++
++
++/*! \brief Create and add popup menu item separator.
++ */
++static void
++x_tabs_menu_create_item_separ (GtkWidget* menu)
++{
++  gtk_menu_shell_append (GTK_MENU_SHELL (menu),
++                         gtk_separator_menu_item_new());
++}
++
++
++
++/*! \brief Create and add popup menu item.
++ */
++static void
++x_tabs_menu_create_item (GschemToplevel* toplevel,
++                         GtkWidget*      menu,
++                         const gchar*    action_name,
++                         const gchar*    action_label,
++                         const gchar*    icon_name)
++{
++  GschemAction* action = gschem_action_new (action_name,  /* name */
++                                            action_label, /* label */
++                                            NULL,         /* tooltip */
++                                            icon_name,    /* stock_id */
++                                            NULL);        /* multikey_accel */
++
++  GtkWidget* item = gtk_action_create_menu_item (GTK_ACTION (action));
++  gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
++
++  g_signal_connect (action,
++                    "activate",
++                    G_CALLBACK (&x_tabs_menu_item_on_activate),
++                    toplevel);
++
++} /* x_tabs_menu_create_item() */
++


### PR DESCRIPTION
Incorporate changes made in lepton-eda PRs [#498](https://github.com/lepton-eda/lepton-eda/pull/498) and [#501](https://github.com/lepton-eda/lepton-eda/pull/501):
- make tabs reorderable with mouse
- add a context menu with common actions to active tab's header widget